### PR TITLE
leverage ServiceConnector to setup connection to keyvault and DB - Keyvault reference

### DIFF
--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -10,13 +10,6 @@ param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'
 
-// Target DB properties
-param connectionStringKey string = ''
-param targetResourceId string = ''
-param appUser string = ''
-@secure()
-param appUserPassword string
-
 module api '../core/host/appservice.bicep' = {
   name: '${name}-app-module'
   params: {
@@ -32,10 +25,6 @@ module api '../core/host/appservice.bicep' = {
     runtimeName: 'dotnetcore'
     runtimeVersion: '6.0'
     scmDoBuildDuringDeployment: false
-    targetResourceId: targetResourceId
-    appUser: appUser
-    appUserPassword: appUserPassword
-    connectionStringKey: connectionStringKey
   }
 }
 

--- a/infra/app/api.bicep
+++ b/infra/app/api.bicep
@@ -10,6 +10,13 @@ param appSettings object = {}
 param keyVaultName string
 param serviceName string = 'api'
 
+// Target DB properties
+param connectionStringKey string = ''
+param targetResourceId string = ''
+param appUser string = ''
+@secure()
+param appUserPassword string
+
 module api '../core/host/appservice.bicep' = {
   name: '${name}-app-module'
   params: {
@@ -25,6 +32,10 @@ module api '../core/host/appservice.bicep' = {
     runtimeName: 'dotnetcore'
     runtimeVersion: '6.0'
     scmDoBuildDuringDeployment: false
+    targetResourceId: targetResourceId
+    appUser: appUser
+    appUserPassword: appUserPassword
+    connectionStringKey: connectionStringKey
   }
 }
 

--- a/infra/app/connection.bicep
+++ b/infra/app/connection.bicep
@@ -1,0 +1,28 @@
+param authType string
+//param appResourceId string
+param targetResourceId string
+param runtimeName string
+param dbUserName string = ''
+param keyVaultName string
+param webAppName string
+param connectionStringKey string = ''
+
+@secure()
+param dbUserPassword string
+
+var resourcePrefix = uniqueString(webAppName)
+
+module connections '../core/host/servicelinker.bicep' = {
+  name: '${resourcePrefix}conns'
+  params: {
+    authType: authType
+    //appResourceId: appResourceId
+    targetResourceId: targetResourceId
+    runtimeName: runtimeName
+    dbUserName: dbUserName
+    dbUserPassword: dbUserPassword
+    keyVaultName: keyVaultName
+    webAppName: webAppName
+    connectionStringKey: connectionStringKey
+  }
+}

--- a/infra/app/db.bicep
+++ b/infra/app/db.bicep
@@ -29,3 +29,4 @@ module sqlServer '../core/database/sqlserver/sqlserver.bicep' = {
 
 output connectionStringKey string = sqlServer.outputs.connectionStringKey
 output databaseName string = sqlServer.outputs.databaseName
+output id string = sqlServer.outputs.id

--- a/infra/app/db.bicep
+++ b/infra/app/db.bicep
@@ -27,5 +27,6 @@ module sqlServer '../core/database/sqlserver/sqlserver.bicep' = {
   }
 }
 
+output connectionStringKey string = sqlServer.outputs.connectionStringKey
 output databaseName string = sqlServer.outputs.databaseName
 output id string = sqlServer.outputs.id

--- a/infra/app/db.bicep
+++ b/infra/app/db.bicep
@@ -27,6 +27,5 @@ module sqlServer '../core/database/sqlserver/sqlserver.bicep' = {
   }
 }
 
-output connectionStringKey string = sqlServer.outputs.connectionStringKey
 output databaseName string = sqlServer.outputs.databaseName
 output id string = sqlServer.outputs.id

--- a/infra/core/database/sqlserver/sqlserver.bicep
+++ b/infra/core/database/sqlserver/sqlserver.bicep
@@ -112,18 +112,10 @@ resource appUserPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = 
   }
 }
 
-resource sqlAzureConnectionStringSercret 'Microsoft.KeyVault/vaults/secrets@2022-07-01' = {
-  parent: keyVault
-  name: connectionStringKey
-  properties: {
-    value: '${connectionString}; Password=${appUserPassword}'
-  }
-}
-
 resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
 }
 
-var connectionString = 'Server=${sqlServer.properties.fullyQualifiedDomainName}; Database=${sqlServer::database.name}; User=${appUser}'
 output connectionStringKey string = connectionStringKey
 output databaseName string = sqlServer::database.name
+output id string = sqlServer.id

--- a/infra/core/database/sqlserver/sqlserver.bicep
+++ b/infra/core/database/sqlserver/sqlserver.bicep
@@ -6,6 +6,7 @@ param appUser string = 'appUser'
 param databaseName string
 param keyVaultName string
 param sqlAdmin string = 'sqlAdmin'
+param connectionStringKey string = 'AZURE-SQL-CONNECTION-STRING'
 
 @secure()
 param sqlAdminPassword string
@@ -115,5 +116,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
 }
 
+output connectionStringKey string = connectionStringKey
 output databaseName string = sqlServer::database.name
 output id string = sqlServer.id

--- a/infra/core/database/sqlserver/sqlserver.bicep
+++ b/infra/core/database/sqlserver/sqlserver.bicep
@@ -6,7 +6,6 @@ param appUser string = 'appUser'
 param databaseName string
 param keyVaultName string
 param sqlAdmin string = 'sqlAdmin'
-param connectionStringKey string = 'AZURE-SQL-CONNECTION-STRING'
 
 @secure()
 param sqlAdminPassword string
@@ -116,6 +115,5 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = {
   name: keyVaultName
 }
 
-output connectionStringKey string = connectionStringKey
 output databaseName string = sqlServer::database.name
 output id string = sqlServer.id

--- a/infra/core/host/appservice.bicep
+++ b/infra/core/host/appservice.bicep
@@ -33,6 +33,13 @@ param numberOfWorkers int = -1
 param scmDoBuildDuringDeployment bool = false
 param use32BitWorkerProcess bool = false
 
+// Target DB properties
+param connectionStringKey string = 'AZURE-SQL-CONNECTION-STRING'
+param targetResourceId string = ''
+param appUser string = ''
+@secure()
+param appUserPassword string = ''
+
 resource appService 'Microsoft.Web/sites@2022-03-01' = {
   name: name
   location: location
@@ -66,8 +73,7 @@ resource appService 'Microsoft.Web/sites@2022-03-01' = {
         SCM_DO_BUILD_DURING_DEPLOYMENT: string(scmDoBuildDuringDeployment)
         ENABLE_ORYX_BUILD: string(enableOryxBuild)
       },
-      !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {},
-      !empty(keyVaultName) ? { AZURE_KEY_VAULT_ENDPOINT: keyVault.properties.vaultUri } : {})
+      !empty(applicationInsightsName) ? { APPLICATIONINSIGHTS_CONNECTION_STRING: applicationInsights.properties.ConnectionString } : {})
   }
 
   resource configLogs 'config' = {
@@ -90,6 +96,61 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = if (!(empty(
 
 resource applicationInsights 'Microsoft.Insights/components@2020-02-02' existing = if (!empty(applicationInsightsName)) {
   name: applicationInsightsName
+}
+
+// if !empty(keyVaultName), create connection to keyvault so that db credentials could be saved into keyvault, 
+// and app service could retrieve secrets from keyvault using managed identity
+resource connectionToKeyVault 'Microsoft.ServiceLinker/linkers@2022-11-01-preview' =  if(!empty(keyVaultName)) {
+  name: 'conn_kv'
+  scope: appService
+  properties: {
+    targetService: {
+      id: keyVault.id
+      type: 'AzureResource'
+    }
+    clientType: 'none'
+    authInfo: {
+      authType: 'systemAssignedIdentity'
+      roles: [
+        '4633458b-17de-408a-b874-0445c86b69e6'
+      ]
+    }
+    configurationInfo: {
+      customizedKeys: {
+        'AZURE_KEYVAULT_RESOURCEENDPOINT': 'AZURE_KEY_VAULT_ENDPOINT'
+      }
+    }
+  }
+}
+
+// if !empty(targetResourceId), create connection to target database, including: 
+// - add db connectionstr (from keyvault if applicable) in webapp appsettings or connectionString(for dotnetcore convention)
+// - allow webapp firewall at target database if applicable (target allows firewall instead of public access)
+resource connectionToTargetDB 'Microsoft.ServiceLinker/linkers@2022-11-01-preview' = if (!empty(targetResourceId)) {
+  name: 'conn_db'
+  scope: appService
+  properties: {
+    targetService: {
+      id: targetResourceId
+      type: 'AzureResource'
+    }
+    secretStore: {
+      keyVaultId: !empty(keyVaultName) ? keyVault.id : ''
+      keyVaultSecretName: !empty(keyVaultName) ? connectionStringKey : ''
+    }
+    authInfo: {
+      authType: 'secret'
+      name: appUser
+      secretInfo: {
+        secretType: 'rawValue'
+        value: appUserPassword
+      }
+    }
+    clientType: 'dotnet'
+  }
+  dependsOn: [
+    connectionToKeyVault
+  ]
 }
 
 output identityPrincipalId string = managedIdentity ? appService.identity.principalId : ''

--- a/infra/core/host/servicelinker.bicep
+++ b/infra/core/host/servicelinker.bicep
@@ -1,0 +1,80 @@
+param authType string
+//param appResourceId string
+param targetResourceId string
+param runtimeName string
+param dbUserName string = ''
+param keyVaultName string
+param webAppName string
+param connectionStringKey string =''
+
+@secure()
+param dbUserPassword string = ''
+
+
+// if !empty(keyVaultName), create connection to keyvault so that db credentials could be saved into keyvault, 
+// and app service could retrieve secrets from keyvault using managed identity
+resource connectionToKeyVault 'Microsoft.ServiceLinker/linkers@2022-11-01-preview' =  if(!empty(keyVaultName)) {
+  name: 'conn_kv'
+  scope: webApp
+  properties: {
+    targetService: {
+      id: keyVault.id
+      type: 'AzureResource'
+    }
+    clientType: 'none'
+    authInfo: {
+      authType: 'systemAssignedIdentity'
+      roles: [
+        '4633458b-17de-408a-b874-0445c86b69e6'
+      ]
+    }
+    configurationInfo: {
+      customizedKeys: {
+        'AZURE_KEYVAULT_RESOURCEENDPOINT': 'AZURE_KEY_VAULT_ENDPOINT'
+      }
+    }
+  }
+  dependsOn: [
+    webApp
+  ]
+}
+
+// if !empty(targetResourceId), create connection to target database, including: 
+// - add db connectionstr (from keyvault if applicable) in webapp appsettings or connectionString(for dotnetcore convention)
+// - allow webapp firewall at target database if applicable (target allows firewall instead of public access)
+resource connectionToTargetDB 'Microsoft.ServiceLinker/linkers@2022-11-01-preview' = if (!empty(targetResourceId)) {
+  name: 'conn_db'
+  scope: webApp
+  properties: {
+    targetService: {
+      id: targetResourceId
+      type: 'AzureResource'
+    }
+    secretStore: {
+      keyVaultId: !empty(keyVaultName) ? keyVault.id : ''
+      keyVaultSecretName: !empty(keyVaultName) ? connectionStringKey : ''
+    }
+    authInfo: {
+      authType: authType
+      name: dbUserName
+      secretInfo: {
+        secretType: 'rawValue'
+        value: dbUserPassword
+      }
+    }
+    clientType: runtimeName
+  }
+  dependsOn: [
+    connectionToKeyVault
+  ]
+}
+
+resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' existing = if (!empty(keyVaultName)) {
+  name: keyVaultName
+  scope: resourceGroup()
+}
+
+resource webApp 'Microsoft.Web/sites@2022-03-01' existing = {
+  name: webAppName
+  scope: resourceGroup()
+}

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -24,6 +24,7 @@ param sqlServerName string = ''
 param sqlDatabaseName string = ''
 param webServiceName string = ''
 param apimServiceName string = ''
+param appUser string = 'appUser'
 
 @description('Flag to use Azure API Management to mediate the calls between the Web frontend and the backend API')
 param useAPIM bool = false
@@ -78,16 +79,10 @@ module api './app/api.bicep' = {
     appSettings: {
       AZURE_SQL_CONNECTION_STRING_KEY: sqlServer.outputs.connectionStringKey
     }
-  }
-}
-
-// Give the API access to KeyVault
-module apiKeyVaultAccess './core/security/keyvault-access.bicep' = {
-  name: 'api-keyvault-access'
-  scope: rg
-  params: {
-    keyVaultName: keyVault.outputs.name
-    principalId: api.outputs.SERVICE_API_IDENTITY_PRINCIPAL_ID
+    targetResourceId: '${sqlServer.outputs.id}/databases/${sqlServer.outputs.databaseName}'
+    appUser: appUser
+    appUserPassword: appUserPassword
+    connectionStringKey: sqlServer.outputs.connectionStringKey
   }
 }
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -76,13 +76,10 @@ module api './app/api.bicep' = {
     appServicePlanId: appServicePlan.outputs.id
     keyVaultName: keyVault.outputs.name
     allowedOrigins: [ web.outputs.SERVICE_WEB_URI ]
-    appSettings: {
-      AZURE_SQL_CONNECTION_STRING_KEY: sqlServer.outputs.connectionStringKey
-    }
     targetResourceId: '${sqlServer.outputs.id}/databases/${sqlServer.outputs.databaseName}'
     appUser: appUser
     appUserPassword: appUserPassword
-    connectionStringKey: sqlServer.outputs.connectionStringKey
+    connectionStringKey: 'AZURE-SQL-CONNECTION-STRING'
   }
 }
 
@@ -167,8 +164,6 @@ module apimApi './app/apim-api.bicep' = if (useAPIM) {
   }
 }
 
-// Data outputs
-output AZURE_SQL_CONNECTION_STRING_KEY string = sqlServer.outputs.connectionStringKey
 
 // App outputs
 output APPLICATIONINSIGHTS_CONNECTION_STRING string = monitoring.outputs.applicationInsightsConnectionString


### PR DESCRIPTION
leverage ServiceConnector to setup connections to keyvault and DB. 
Use AppService Keyvault reference feature to refer secrets in Keyvault, instead of direct access keyvault.
- both local debug and cloud experience work
- Keyvault reference in Appservice feature provides more security in cloud.
- customize output name(appsetting names) like sample https://github.com/Azure-Samples/todo-csharp-sql/pull/1/files#diff-c49282ec82c441d0ca28744efdbdae6288715e320eb90772ac149c9096f7eeedR118-R120